### PR TITLE
Fix the version number in the .control files

### DIFF
--- a/adaptive/adaptive_counter.control
+++ b/adaptive/adaptive_counter.control
@@ -1,5 +1,5 @@
 # adaptive estimator
 comment = 'Aggregation functions and data type for distinct estimation based on adaptive sampling.'
-default_version = '1.0'
+default_version = '1.1'
 relocatable = true
 module_pathname = '$libdir/adaptive_counter'

--- a/bitmap/bitmap_counter.control
+++ b/bitmap/bitmap_counter.control
@@ -1,6 +1,6 @@
 # s-bitmap estimator control
 comment = 'Aggregation functions and data type for distinct estimation based on s-bitmap.'
-default_version = '1.0'
+default_version = '1.1'
 relocatable = true
 
 module_pathname = '$libdir/bitmap_counter'

--- a/pcsa/pcsa_counter.control
+++ b/pcsa/pcsa_counter.control
@@ -1,6 +1,6 @@
 # PCSA estimator control
 comment = 'Aggregation functions and data type for distinct estimation based on PCSA.'
-default_version = '1.0'
+default_version = '1.1'
 relocatable = true
 
 module_pathname = '$libdir/pcsa_counter'

--- a/probabilistic/probabilistic_counter.control
+++ b/probabilistic/probabilistic_counter.control
@@ -1,6 +1,6 @@
 # probabilistic estimator control
 comment = 'Aggregation functions and data type for distinct estimation based on Probabilistic counting.'
-default_version = '1.0'
+default_version = '1.1'
 relocatable = true
 
 module_pathname = '$libdir/probabilistic_counter'


### PR DESCRIPTION
Currently the default version number in the .control files is set to 1.0 

postgres=# CREATE EXTENSION adaptive_counter;
ERROR:  could not stat file "/usr/share/postgresql/9.1/extension/adaptive_counter--1.0.sql": No such file or directory
